### PR TITLE
Renaming hiding fields

### DIFF
--- a/benchmarks/src/main/java/org/elasticsearch/benchmark/search/aggregations/AggConstructionContentionBenchmark.java
+++ b/benchmarks/src/main/java/org/elasticsearch/benchmark/search/aggregations/AggConstructionContentionBenchmark.java
@@ -161,19 +161,19 @@ public class AggConstructionContentionBenchmark {
         private final MultiBucketConsumer multiBucketConsumer;
 
         DummyAggregationContext(long bytesToPreallocate) {
-            CircuitBreakerService breakerService;
+            CircuitBreakerService dummyBreakerService;
             if (preallocateBreaker) {
-                breakerService = preallocated = new PreallocatedCircuitBreakerService(
-                    AggConstructionContentionBenchmark.this.breakerService,
+                dummyBreakerService = preallocated = new PreallocatedCircuitBreakerService(
+                    AggConstructionContentionBenchmark.this.dummyBreakerService,
                     CircuitBreaker.REQUEST,
                     bytesToPreallocate,
                     "aggregations"
                 );
             } else {
-                breakerService = AggConstructionContentionBenchmark.this.breakerService;
+                dummyBreakerService = AggConstructionContentionBenchmark.this.dummyBreakerService;
                 preallocated = null;
             }
-            breaker = breakerService.getBreaker(CircuitBreaker.REQUEST);
+            breaker = dummyBreakerService.getBreaker(CircuitBreaker.REQUEST);
             multiBucketConsumer = new MultiBucketConsumer(Integer.MAX_VALUE, breaker);
         }
 
@@ -329,9 +329,9 @@ public class AggConstructionContentionBenchmark {
 
         @Override
         public void close() {
-            List<Releasable> releaseMe = new ArrayList<>(this.releaseMe);
-            releaseMe.add(preallocated);
-            Releasables.close(releaseMe);
+            List<Releasable> closeReleaseMe = new ArrayList<>(this.releaseMe);
+            closeReleaseMe.add(preallocated);
+            Releasables.close(closeReleaseMe);
         }
     }
 }

--- a/benchmarks/src/main/java/org/elasticsearch/common/RoundingBenchmark.java
+++ b/benchmarks/src/main/java/org/elasticsearch/common/RoundingBenchmark.java
@@ -100,17 +100,17 @@ public class RoundingBenchmark {
 
     @Benchmark
     public void round(Blackhole bh) {
-        Rounding.Prepared rounder = rounderBuilder.get();
+        Rounding.Prepared rounders = rounderBuilder.get();
         for (int i = 0; i < dates.length; i++) {
-            bh.consume(rounder.round(dates[i]));
+            bh.consume(rounders.round(dates[i]));
         }
     }
 
     @Benchmark
     public void nextRoundingValue(Blackhole bh) {
-        Rounding.Prepared rounder = rounderBuilder.get();
+        Rounding.Prepared nextRounder = rounderBuilder.get();
         for (int i = 0; i < dates.length; i++) {
-            bh.consume(rounder.nextRoundingValue(dates[i]));
+            bh.consume(nextRounder.nextRoundingValue(dates[i]));
         }
     }
 }

--- a/buildSrc/src/main/java/org/elasticsearch/gradle/ElasticsearchDistribution.java
+++ b/buildSrc/src/main/java/org/elasticsearch/gradle/ElasticsearchDistribution.java
@@ -141,8 +141,8 @@ public class ElasticsearchDistribution implements Buildable, Iterable<File> {
     }
 
     public boolean isDocker() {
-        final Type type = this.type.get();
-        return type == Type.DOCKER || type == Type.DOCKER_UBI;
+        final Type actualType = this.type.get();
+        return actualType == Type.DOCKER || actualType == Type.DOCKER_UBI;
     }
 
     public void setBundledJdk(Boolean bundledJdk) {


### PR DESCRIPTION
Avoid to hide some fields in the modified class in order to ensure that there is no confusion for programmers