### PR TITLE
Atomic changes on containts

### DIFF
--- a/libs/nio/src/main/java/org/elasticsearch/nio/RoundRobinSupplier.java
+++ b/libs/nio/src/main/java/org/elasticsearch/nio/RoundRobinSupplier.java
@@ -10,12 +10,13 @@ package org.elasticsearch.nio;
 
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReferenceArray;
 import java.util.function.Supplier;
 
 final class RoundRobinSupplier<S> implements Supplier<S> {
 
     private final AtomicBoolean selectorsSet = new AtomicBoolean(false);
-    private volatile S[] selectors;
+    private AtomicReferenceArray S[] selectors;
     private AtomicInteger counter = new AtomicInteger(0);
 
     RoundRobinSupplier() {

--- a/libs/nio/src/main/java/org/elasticsearch/nio/RoundRobinSupplier.java
+++ b/libs/nio/src/main/java/org/elasticsearch/nio/RoundRobinSupplier.java
@@ -16,7 +16,7 @@ import java.util.function.Supplier;
 final class RoundRobinSupplier<S> implements Supplier<S> {
 
     private final AtomicBoolean selectorsSet = new AtomicBoolean(false);
-    private AtomicReferenceArray S[] selectors;
+    private AtomicReferenceArray S selectors;
     private AtomicInteger counter = new AtomicInteger(0);
 
     RoundRobinSupplier() {

--- a/server/src/main/java/org/apache/lucene/queries/BlendedTermQuery.java
+++ b/server/src/main/java/org/apache/lucene/queries/BlendedTermQuery.java
@@ -30,6 +30,7 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import java.util.concurrent.atomic.AtomicReferenceArray;
 /**
  * BlendedTermQuery can be used to unify term statistics across
  * one or more fields in the index. A common problem with structured
@@ -283,7 +284,7 @@ public abstract class BlendedTermQuery extends Query {
         }
     }
 
-    private volatile TermAndBoost[] equalTermsAndBoosts = null;
+    private AtomicReferenceArray equalTermsAndBoosts = null;
 
     private TermAndBoost[] equalsTermsAndBoosts() {
         if (equalTermsAndBoosts != null) {

--- a/server/src/main/java/org/elasticsearch/action/bulk/TransportBulkAction.java
+++ b/server/src/main/java/org/elasticsearch/action/bulk/TransportBulkAction.java
@@ -734,7 +734,7 @@ public class TransportBulkAction extends HandledTransportAction<BulkRequest, Bul
         final List<BulkItemResponse> itemResponses;
         final AtomicIntegerArray originalSlots;
 
-        volatile int currentSlot = -1;
+        AtomicInteger currentSlot = -1;
 
         BulkRequestModifier(BulkRequest bulkRequest) {
             this.bulkRequest = bulkRequest;
@@ -745,7 +745,7 @@ public class TransportBulkAction extends HandledTransportAction<BulkRequest, Bul
 
         @Override
         public DocWriteRequest<?> next() {
-            return bulkRequest.requests().get(++currentSlot);
+            return bulkRequest.requests().currentSlot.incrementAndGet();
         }
 
         @Override

--- a/server/src/main/java/org/elasticsearch/action/fieldcaps/TransportFieldCapabilitiesIndexAction.java
+++ b/server/src/main/java/org/elasticsearch/action/fieldcaps/TransportFieldCapabilitiesIndexAction.java
@@ -51,6 +51,7 @@ import org.elasticsearch.transport.TransportException;
 import org.elasticsearch.transport.TransportRequestHandler;
 import org.elasticsearch.transport.TransportResponseHandler;
 import org.elasticsearch.transport.TransportService;
+import java.util.concurrent.atomic.AtomicReferenceArray;
 
 import java.io.IOException;
 import java.util.Collections;
@@ -183,7 +184,7 @@ public class TransportFieldCapabilitiesIndexAction
         private final ActionListener<FieldCapabilitiesIndexResponse> listener;
         private final GroupShardsIterator<ShardIterator> shardsIt;
 
-        private volatile int shardIndex = 0;
+        private AtomicInteger shardIndex = 0;
 
         private AsyncShardsAction(FieldCapabilitiesIndexRequest request, ActionListener<FieldCapabilitiesIndexResponse> listener) {
             this.listener = listener;
@@ -232,7 +233,7 @@ public class TransportFieldCapabilitiesIndexAction
         }
 
         private void moveToNextShard() {
-            ++ shardIndex;
+            shardIndex.incrementAndGet();
         }
 
         private void tryNext(@Nullable final Exception lastFailure, boolean canMatchShard) {

--- a/server/src/main/java/org/elasticsearch/common/util/PlainIterator.java
+++ b/server/src/main/java/org/elasticsearch/common/util/PlainIterator.java
@@ -11,6 +11,7 @@ package org.elasticsearch.common.util;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
 
 public class PlainIterator<T> implements Iterable<T>, Countable {
     private final List<T> elements;
@@ -18,7 +19,7 @@ public class PlainIterator<T> implements Iterable<T>, Countable {
     // Calls to nextOrNull might be performed on different threads in the transport actions so we need the volatile
     // keyword in order to ensure visibility. Note that it is fine to use `volatile` for a counter in that case given
     // that although nextOrNull might be called from different threads, it can never happen concurrently.
-    private volatile int index;
+    private AtomicInteger index;
 
     public PlainIterator(List<T> elements) {
         this.elements = elements;
@@ -37,7 +38,7 @@ public class PlainIterator<T> implements Iterable<T>, Countable {
         if (index == elements.size()) {
             return null;
         } else {
-            return elements.get(index++);
+            return index.incrementAndGet();
         }
     }
 

--- a/server/src/main/java/org/elasticsearch/http/HttpTracer.java
+++ b/server/src/main/java/org/elasticsearch/http/HttpTracer.java
@@ -19,6 +19,7 @@ import org.elasticsearch.rest.RestRequest;
 import org.elasticsearch.rest.RestResponse;
 import org.elasticsearch.tasks.Task;
 import org.elasticsearch.transport.TransportService;
+import java.util.concurrent.atomic.AtomicReferenceArray;
 
 import java.util.List;
 
@@ -29,8 +30,8 @@ class HttpTracer {
 
     private final Logger logger = LogManager.getLogger(HttpTracer.class);
 
-    private volatile String[] tracerLogInclude;
-    private volatile String[] tracerLogExclude;
+    private AtomicReferenceArray tracerLogInclude;
+    private AtomicReferenceArray tracerLogExclude;
 
     HttpTracer(Settings settings, ClusterSettings clusterSettings) {
 


### PR DESCRIPTION
Avoid data-race on some integers used among the code. 
Also avoid unexpected behavior of some array that were declared as volatile and so the containt was not atomic.
