### PR TITLE
Assert without side effects

### DIFF
--- a/server/src/main/java/org/elasticsearch/cluster/SnapshotDeletionsInProgress.java
+++ b/server/src/main/java/org/elasticsearch/cluster/SnapshotDeletionsInProgress.java
@@ -42,8 +42,11 @@ public class SnapshotDeletionsInProgress extends AbstractNamedDiffable<Custom> i
 
     private SnapshotDeletionsInProgress(List<Entry> entries) {
         this.entries = entries;
-        assert entries.size() == entries.stream().map(Entry::uuid).distinct().count() : "Found duplicate UUIDs in entries " + entries;
-        assert assertNoConcurrentDeletionsForSameRepository(entries);
+        int entriesSize = entries.size();
+        int intendedSize = entries.stream().map(Entry::uuid).distinct().count();
+        assert entriesSize == intendedSize : "Found duplicate UUIDs in entries " + entries;
+        boolean nonConcurrentDeletions = assertNoConcurrentDeletionsForSameRepository(entries)
+        assert nonConcurrentDeletions;
     }
 
     public static SnapshotDeletionsInProgress of(List<SnapshotDeletionsInProgress.Entry> entries) {


### PR DESCRIPTION
Instead of asserting directly on the side-effects thus triggered, firstly put those side-effects in variables, should improve the readability of the global context. The messages haven't been modified. 